### PR TITLE
Hotfix for transposition table

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ module.exports = {
     // The starting position represented as a FEN string
     fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
     // Current version to show in UCI
-    version: "v0.4.0",
+    version: "v0.4.2",
     // Late move reduction config
     lmrFullDepth: 4, // Number of moves to be searched in full depth
     lmrMaxReduction: 3 // Only apply LMR above this depth
@@ -76,7 +76,7 @@ module.exports = {
     * Killer heuristic.
     * History heuristic.
     * Countermove heuristic.
-* Transposition table (disabled).
+* Transposition table (enabled without Zobrist hashing).
 * Null-move pruning.
 * Late move reductions.
 * Checkmate and stalemate detection.

--- a/catto.config.js
+++ b/catto.config.js
@@ -2,11 +2,11 @@ module.exports = {
     searchDepth: 5,
     uci: true,
     fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
-    version: "v0.4.1",
+    version: "v0.4.2",
 
     // For dev
     debug: false,
-    stable: true,
+    // stable: true,
     lmrFullDepth: 4,
     lmrMaxReduction: 3
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catto",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "The Catto chess engine",
   "main": "index.js",
   "scripts": {

--- a/src/core.ts
+++ b/src/core.ts
@@ -70,9 +70,10 @@ export class Engine {
     public hashTable: Record<string, HashEntry> = {};
 
     recordHash(score: number, depth: number, hashFlag: HashFlag) {
-        if (this.stable) return;
+        // if (this.stable) return;
 
-        const hash = genZobristKey(this.chess).toString();
+        // const hash = genZobristKey(this.chess).toString();
+        const hash = this.chess.fen();
         
         this.hashTable[hash] = {
             score,
@@ -82,7 +83,8 @@ export class Engine {
     }
 
     probeHash(alpha: number, beta: number, depth: number): number {
-        const hash = genZobristKey(this.chess).toString();
+        // const hash = genZobristKey(this.chess).toString();
+        const hash = this.chess.fen();
 
         const hashEntry = this.hashTable[hash];
 
@@ -90,7 +92,7 @@ export class Engine {
             // If position does not exist the transposition table
             return 99999;
         
-        if (depth >= hashEntry.depth) {
+        if (depth <= hashEntry.depth) {
             let score = hashEntry.score;
 
             if (score < -48000) score += this.ply;
@@ -345,9 +347,14 @@ export class Engine {
     }
 
     findMove() {
+        const start = Date.now();
+
         this.negamax(this.searchDepth, -50000, 50000);
 
-        if (this.debug) console.log("Nodes searched:", this.nodes);
+        if (this.debug) {
+            console.log("Nodes searched:", this.nodes);
+            console.log(`Finished in: ${Date.now() - start}ms`); 
+        };
 
         return this.bestMove;
     }


### PR DESCRIPTION
- Fixed a mistake where the lower depth hash node is actually chosen.
- Temporarily use FEN rather than Zobrist because there are some problems with it.
