### PR TITLE
Add mate info in UCI client

### DIFF
--- a/catto.config.js
+++ b/catto.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     // Current version to show in UCI
-    version: "v0.12.1",
+    version: "v0.12.2",
     // Late move reduction config
     lmrFullDepth: 4, // Number of moves to be searched in full depth
     lmrMaxReduction: 3, // Only apply LMR above this depth

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catto",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "The Catto chess engine",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add mate info in UCI client. Prior to this, the engine would just send out ridiculously high/low points rather than sending out a `mate` option which can be annoying.
