### PR TITLE
Move ordering fix

### DIFF
--- a/catto.config.js
+++ b/catto.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     // Current version to show in UCI
-    version: "v0.12.4",
+    version: "v0.12.5",
     // Late move reduction config
     lmrFullDepth: 4, // Number of moves to be searched in full depth
     lmrMaxReduction: 3, // Only apply LMR above this depth

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catto",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "The Catto chess engine",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Counter move heuristic: Priority got reduced to be lower than killer moves. Map is used now rather than object.
- History heuristic: This used to not work at all due to NaN, but it is fixed now. Map is also used now.